### PR TITLE
Disable change animation if payloads are present for changed items

### DIFF
--- a/library/src/main/java/com/mikepenz/itemanimators/BaseItemAnimator.java
+++ b/library/src/main/java/com/mikepenz/itemanimators/BaseItemAnimator.java
@@ -750,6 +750,14 @@ public abstract class BaseItemAnimator<T> extends SimpleItemAnimator {
             ViewCompat.animate(viewHolders.get(i).itemView).cancel();
         }
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean canReuseUpdatedViewHolder(@NonNull ViewHolder viewHolder, @NonNull List<Object> payloads) {
+        return !payloads.isEmpty() || super.canReuseUpdatedViewHolder(viewHolder, payloads);
+    }
 
     private static class VpaListenerAdapter implements ViewPropertyAnimatorListener {
         @Override


### PR DESCRIPTION
The default DefaultItemAnimator class [disables change animations](https://github.com/aosp-mirror/platform_frameworks_base/blob/abac8f7a86ef86b15aac45bc77b5ef1394a8e3bc/core/java/com/android/internal/widget/DefaultItemAnimator.java#L664) if change payloads were supplied along with notifyItemChanged(). This commit duplicates this behavior in all custom animations provided by this library.


